### PR TITLE
Ignore .vscode in code checks

### DIFF
--- a/ScriptsBase/Checks/CodeChecksBase.cs
+++ b/ScriptsBase/Checks/CodeChecksBase.cs
@@ -63,6 +63,7 @@ public abstract class CodeChecksBase<T>
     protected virtual IEnumerable<Regex> DefaultIgnoredFilePaths { get; } = new List<Regex>
     {
         new(@"\.vs/"),
+        new(@"\.vscode/"),
         new(@"\.idea/"),
         new(@"\.mono/"),
         new(@"\.import/"),


### PR DESCRIPTION
I figured out how to debug Godot using VSCode, which involves the creation of a `launch.json` file inside `.vscode`. It kept tripping up the linter though, so I think it's a good idea to ignore the .vscode folder during the code check.