### PR TITLE
Update Rule SA1615 ElementReturnValueMustBeDocumented to Not Show Warnings

### DIFF
--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -151,7 +151,7 @@
     <Rule Id="SA1612" Action="Warning" /> <!-- ElementParameterDocumentationMustMatchElementParameters -->
     <Rule Id="SA1613" Action="Warning" /> <!-- ElementParameterDocumentationMustDeclareParameterName -->
     <Rule Id="SA1614" Action="Warning" /> <!-- ElementParameterDocumentationMustHaveText -->
-    <Rule Id="SA1615" Action="None" /> <!-- ElementReturnValueMustBeDocumented -->
+    <Rule Id="SA1615" Action="Info" /> <!-- ElementReturnValueMustBeDocumented -->
     <Rule Id="SA1617" Action="Warning" /> <!-- VoidReturnValueMustNotBeDocumented -->
     <Rule Id="SA1622" Action="Warning" /> <!-- GenericTypeParameterDocumentationMustHaveText -->
     <Rule Id="SA1623" Action="None" /> <!-- Property summary documentation should match accessors, checked by JetBrains instead -->

--- a/StyleCop.ruleset
+++ b/StyleCop.ruleset
@@ -151,6 +151,7 @@
     <Rule Id="SA1612" Action="Warning" /> <!-- ElementParameterDocumentationMustMatchElementParameters -->
     <Rule Id="SA1613" Action="Warning" /> <!-- ElementParameterDocumentationMustDeclareParameterName -->
     <Rule Id="SA1614" Action="Warning" /> <!-- ElementParameterDocumentationMustHaveText -->
+    <Rule Id="SA1615" Action="None" /> <!-- ElementReturnValueMustBeDocumented -->
     <Rule Id="SA1617" Action="Warning" /> <!-- VoidReturnValueMustNotBeDocumented -->
     <Rule Id="SA1622" Action="Warning" /> <!-- GenericTypeParameterDocumentationMustHaveText -->
     <Rule Id="SA1623" Action="None" /> <!-- Property summary documentation should match accessors, checked by JetBrains instead -->


### PR DESCRIPTION
Currently, almost none of the files in Thrive pass the SA1615 Stylecop rule without a warning. After a few files are open, the warning section of my editor gets flooded by this one particular type of warning, distracting me from the warnings actually relevant to my code. This rule was previously not configured at all in the stylecop ruleset.