### PR TITLE
refactor check logic code (part 1/3)

### DIFF
--- a/ScriptsBase/Checks/CleanupCode.cs
+++ b/ScriptsBase/Checks/CleanupCode.cs
@@ -7,9 +7,9 @@ using SharedBase.Utilities;
 
 public class CleanupCode : JetBrainsCheck
 {
-    public const string FULL_NO_XML_PROFILE = "full_no_xml";
+    private const string FULL_NO_XML_PROFILE = "full_no_xml";
 
-    public string CleanUpProfile { get; set; } = FULL_NO_XML_PROFILE;
+    private static string CleanUpProfile => FULL_NO_XML_PROFILE;
 
     protected override async Task RunJetBrainsTool(CodeCheckRun runData, CancellationToken cancellationToken)
     {

--- a/ScriptsBase/Checks/CodeCheckRun.cs
+++ b/ScriptsBase/Checks/CodeCheckRun.cs
@@ -13,12 +13,12 @@ using Utilities;
 /// </summary>
 public sealed class CodeCheckRun : IDisposable
 {
-    private readonly object outputLock = new();
+    private readonly Lock outputLock = new();
     private readonly SemaphoreSlim dotnetToolRestoreMutex = new(1);
 
     private bool toolsRestored;
 
-    private List<Regex> ignorePatterns = new();
+    private List<Regex> ignorePatterns = [];
 
     public bool Errors { get; private set; }
 
@@ -39,38 +39,15 @@ public sealed class CodeCheckRun : IDisposable
     /// <returns>True if the file should be processed</returns>
     public bool ProcessFile(string file)
     {
-        if (OnlyCheckFiles != null)
-        {
-            foreach (var onlyCheckFile in OnlyCheckFiles)
-            {
-                if (file.EndsWith(onlyCheckFile))
-                {
-                    // Apply ignoring on top of the specific list of files to ignore
-                    if (IsFileIgnored(file))
-                        return false;
+        if (OnlyCheckFiles == null || OnlyCheckFiles.Any(file.EndsWith))
+            return !IsFileIgnored(file);
 
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        if (IsFileIgnored(file))
-            return false;
-
-        return true;
+        return false;
     }
 
     public bool IsFileIgnored(string file)
     {
-        foreach (var ignorePattern in ignorePatterns)
-        {
-            if (ignorePattern.IsMatch(file))
-                return true;
-        }
-
-        return false;
+        return ignorePatterns.Any(ignorePattern => ignorePattern.IsMatch(file));
     }
 
     public async Task<bool> CheckDotnetTools()
@@ -93,13 +70,11 @@ public sealed class CodeCheckRun : IDisposable
             toolsRestored = true;
 
             OutputInfoWithMutex("Restoring dotnet tools to make sure they are up to date");
-            if (!await DotnetToolInstaller.InstallDotnetTools())
-            {
-                ReportError("Failed to run dotnet tool restore");
-                return false;
-            }
+            if (await DotnetToolInstaller.InstallDotnetTools())
+                return true;
 
-            return true;
+            ReportError("Failed to run dotnet tool restore");
+            return false;
         }
         finally
         {
@@ -199,10 +174,10 @@ public sealed class CodeCheckRun : IDisposable
 
     private void Dispose(bool disposing)
     {
-        if (disposing)
-        {
-            dotnetToolRestoreMutex.Dispose();
-            BuildMutex.Dispose();
-        }
+        if (!disposing)
+            return;
+
+        dotnetToolRestoreMutex.Dispose();
+        BuildMutex.Dispose();
     }
 }

--- a/ScriptsBase/Checks/CodeChecksBase.cs
+++ b/ScriptsBase/Checks/CodeChecksBase.cs
@@ -17,20 +17,12 @@ using Utilities;
 ///   Base class for handling running configured <see cref="CodeCheck"/>s
 /// </summary>
 /// <typeparam name="T">The type of the options class</typeparam>
-public abstract class CodeChecksBase<T>
+public abstract class CodeChecksBase<T>(T options)
     where T : CheckOptionsBase
 {
-    public const int MAX_RUNTIME_MINUTES = 45;
+    protected readonly T options = options;
 
-    protected readonly T options;
-
-    protected CodeChecksBase(T options)
-    {
-        this.options = options;
-        RunData = new CodeCheckRun();
-    }
-
-    public CodeCheckRun RunData { get; }
+    private const int MAX_RUNTIME_MINUTES = 45;
 
     /// <summary>
     ///   The valid checks that exist. Note this should not create a new dictionary each time this is accessed
@@ -42,25 +34,55 @@ public abstract class CodeChecksBase<T>
     /// <summary>
     ///   Extra warnings to ignore in inspections that I couldn't figure out how to suppress normally
     /// </summary>
-    protected virtual IEnumerable<string> ForceIgnoredJetbrainsInspections => new string[] { };
+    protected virtual IEnumerable<string> ForceIgnoredJetbrainsInspections => [];
 
     /// <summary>
     ///   Sends extra wildcards on top of <see cref="InspectCode.InspectCodeIgnoredFilesWildcards"/> to be ignored
     ///   in code inspection
     /// </summary>
-    protected virtual IEnumerable<string> ExtraIgnoredJetbrainsInspectWildcards => new string[] { };
+    protected virtual IEnumerable<string> ExtraIgnoredJetbrainsInspectWildcards => [];
 
     /// <summary>
     ///   Extra ignore wildcards for JetBrains cleanup code
     /// </summary>
-    protected virtual IEnumerable<string> ExtraIgnoredJetbrainsCleanUpWildcards => new string[] { };
+    protected virtual IEnumerable<string> ExtraIgnoredJetbrainsCleanUpWildcards => [];
 
     protected virtual IEnumerable<string> DefaultChecks => ValidChecks.Keys;
+
+    private CodeCheckRun RunData { get; } = new();
 
     /// <summary>
     ///   Project specific file paths to always ignore
     /// </summary>
-    protected List<Regex> FilePathsToAlwaysIgnore { get; set; } = new();
+    private List<Regex> FilePathsToAlwaysIgnore { get; } = [];
+
+    /// <summary>
+    ///   Because we rebuild ourselves when checking, we need to be sure that we have loaded all of our DLLs before we
+    ///   start checks. That's what this method does by calling methods from all DLLs we need.
+    /// </summary>
+    private static void EnsureAllComponentsAreLoaded()
+    {
+        var po = new POParser();
+
+        // This needs enough dummy data to get everything loaded
+        po.Parse(@"# A comment
+#
+msgid """"
+msgstr """"
+""Project-Id-Version: PROJECT VERSION\n""
+""Report-Msgid-Bugs-To: EMAIL@ADDRESS\n""
+""Language: en\n""
+""MIME-Version: 1.0\n""
+""Content-Type: text/plain; charset=UTF-8\n""
+""Content-Transfer-Encoding: 8bit\n""
+""Plural-Forms: nplurals=2; plural=n != 1;\n""
+
+#: some file:3
+#, fuzzy
+msgid ""MSG_ID""
+msgstr ""Translation""
+");
+    }
 
     /// <summary>
     ///   Default set of editor and temp files to ignore
@@ -160,10 +182,7 @@ public abstract class CodeChecksBase<T>
 
     public bool IsRunningInCI()
     {
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI_COMMIT_HASH")))
-            return true;
-
-        return false;
+        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI_COMMIT_HASH"));
     }
 
     private async Task RunActualChecks(List<CodeCheck> selectedChecks, CancellationTokenSource tokenSource)
@@ -205,7 +224,7 @@ public abstract class CodeChecksBase<T>
 
                 if (RunData.Errors)
                 {
-                    tokenSource.Cancel();
+                    await tokenSource.CancelAsync();
                 }
 
                 if (cancellationToken.IsCancellationRequested)
@@ -268,50 +287,16 @@ public abstract class CodeChecksBase<T>
             if (!ValidChecks.TryGetValue(checkName, out var check))
             {
                 RunData.OutputErrorWithMutex($"Unknown check name: {checkName}, valid names: {validNames}");
-                {
-                    return 1;
-                }
+                return 1;
             }
 
             selectedChecks.Add(check);
         }
 
-        if (selectedChecks.Count < 1)
-        {
-            RunData.OutputErrorWithMutex($"No checks selected. Available checks: {validNames}");
-            {
-                return 1;
-            }
-        }
+        if (selectedChecks.Count >= 1)
+            return 0;
 
-        return 0;
-    }
-
-    /// <summary>
-    ///   Because we rebuild ourselves when checking, we need to be sure that we have loaded all of our DLLs before we
-    ///   start checks. That's what this method does by calling methods from all DLLs we need.
-    /// </summary>
-    private void EnsureAllComponentsAreLoaded()
-    {
-        var po = new POParser();
-
-        // This needs enough dummy data to get everything loaded
-        po.Parse(@"# A comment
-#
-msgid """"
-msgstr """"
-""Project-Id-Version: PROJECT VERSION\n""
-""Report-Msgid-Bugs-To: EMAIL@ADDRESS\n""
-""Language: en\n""
-""MIME-Version: 1.0\n""
-""Content-Type: text/plain; charset=UTF-8\n""
-""Content-Transfer-Encoding: 8bit\n""
-""Plural-Forms: nplurals=2; plural=n != 1;\n""
-
-#: some file:3
-#, fuzzy
-msgid ""MSG_ID""
-msgstr ""Translation""
-");
+        RunData.OutputErrorWithMutex($"No checks selected. Available checks: {validNames}");
+        return 1;
     }
 }

--- a/ScriptsBase/Checks/CodeChecksBase.cs
+++ b/ScriptsBase/Checks/CodeChecksBase.cs
@@ -49,6 +49,36 @@ public abstract class CodeChecksBase<T>(T options)
 
     protected virtual IEnumerable<string> DefaultChecks => ValidChecks.Keys;
 
+    /// <summary>
+    ///   Default set of editor and temp files to ignore
+    /// </summary>
+    protected virtual IEnumerable<Regex> DefaultIgnoredFilePaths { get; } = new List<Regex>
+    {
+        new(@"\.vs/"),
+        new(@"\.vscode/"),
+        new(@"\.idea/"),
+        new(@"\.mono/"),
+        new(@"\.import/"),
+        new(@"\.DotSettings$"),
+        new("/?tmp/"),
+        new("/?RubySetupSystem/"),
+        new("/?bin/"),
+        new("/?obj/"),
+        new(@"\.out$"),
+        new("~$"),
+        new(@"\.bak$"),
+        new(@"\.git/"),
+        new("/?builds/", RegexOptions.IgnoreCase),
+        new("/?build/", RegexOptions.IgnoreCase),
+        new("/?build-debug/", RegexOptions.IgnoreCase),
+        new("/?dist/", RegexOptions.IgnoreCase),
+        new("/?native_libs/"),
+        new("/?symbols/", RegexOptions.IgnoreCase),
+        new(LocalizationCheckBase.LOCALE_TEMP_SUFFIX + "$"),
+        new(JetBrainsCheck.JET_BRAINS_CACHE + "/"),
+        new(InspectCode.InspectResultFile),
+    }.Concat(InspectCode.InspectCodeIgnoredFiles).ToList();
+
     private CodeCheckRun RunData { get; } = new();
 
     /// <summary>
@@ -83,36 +113,6 @@ msgid ""MSG_ID""
 msgstr ""Translation""
 ");
     }
-
-    /// <summary>
-    ///   Default set of editor and temp files to ignore
-    /// </summary>
-    protected virtual IEnumerable<Regex> DefaultIgnoredFilePaths { get; } = new List<Regex>
-    {
-        new(@"\.vs/"),
-        new(@"\.vscode/"),
-        new(@"\.idea/"),
-        new(@"\.mono/"),
-        new(@"\.import/"),
-        new(@"\.DotSettings$"),
-        new("/?tmp/"),
-        new("/?RubySetupSystem/"),
-        new("/?bin/"),
-        new("/?obj/"),
-        new(@"\.out$"),
-        new("~$"),
-        new(@"\.bak$"),
-        new(@"\.git/"),
-        new("/?builds/", RegexOptions.IgnoreCase),
-        new("/?build/", RegexOptions.IgnoreCase),
-        new("/?build-debug/", RegexOptions.IgnoreCase),
-        new("/?dist/", RegexOptions.IgnoreCase),
-        new("/?native_libs/"),
-        new("/?symbols/", RegexOptions.IgnoreCase),
-        new(LocalizationCheckBase.LOCALE_TEMP_SUFFIX + "$"),
-        new(JetBrainsCheck.JET_BRAINS_CACHE + "/"),
-        new(InspectCode.InspectResultFile),
-    }.Concat(InspectCode.InspectCodeIgnoredFiles).ToList();
 
     /// <summary>
     ///   Runs the code checks with the specified options given to the constructor


### PR DESCRIPTION
When working on Revolutionary-Games/Thrive#4444, I noticed that there are some old codes there that triggers IDE's code analysis suggestions, so I opened this PR to fix those issues. 
- All files are under the `ScriptsBase/Checks` folder. 
- the whole change is splited into 3 PRs